### PR TITLE
Analyze screenshot for bot mcq capability

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -25,6 +25,18 @@ interface Question {
   explanation: string;
 }
 
+interface QuestionStats {
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+  total: number;
+  lastUpdated?: number; // timestamp for batch updates
+  messageIds?: { // track message IDs for updates
+    [chatId: string]: number;
+  };
+}
+
 interface DiscountButton {
   id: string;
   name: string;


### PR DESCRIPTION
Add `QuestionStats` interface to enable live percentage display for MCQ answers.

---
<a href="https://cursor.com/background-agent?bcId=bc-4edc3a3b-17d1-4117-addf-88dc3bb5ef50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4edc3a3b-17d1-4117-addf-88dc3bb5ef50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

